### PR TITLE
Add Travis CI and Coveralls Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=pypy
+  - TOX_ENV=coverage
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Python Device Cloud Library
 ===========================
 
+[![Build Status](https://travis-ci.org/Etherios/python-devicecloud.svg?branch=master)](https://travis-ci.org/Etherios/python-devicecloud)
+[![Coverage Status](https://img.shields.io/coveralls/Etherios/python-devicecloud.svg)](https://coveralls.io/r/Etherios/python-devicecloud)
+
 Be sure to check out the [full API
 documentation](http://etherios.github.io/python-devicecloud) as well.
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,12 @@ deps=
   httpretty
   nose
 commands=nosetests
+
+[testenv:coverage]
+deps=
+  {[testenv]deps}
+  coverage
+  coveralls
+commands =
+  coverage run --branch --omit={envdir}/* {envbindir}/nosetests
+  coveralls


### PR DESCRIPTION
Doing this pull request on github as testing this is only really possible on the public repository.  There may be a couple of directories that could be ignored when computing the coverage percentage, but it seems mostly accurate.

The coveralls badge may not show a proper image until a build against master is performed.  Adding "`?branch=travis-ci-support`" does yield a valid image.

Please review @tpmanley and @swstack 
