### PR TITLE
docs: Add additional badges based on pypi package information

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ Python Device Cloud Library
 
 [![Build Status](https://travis-ci.org/Etherios/python-devicecloud.svg?branch=master)](https://travis-ci.org/Etherios/python-devicecloud)
 [![Coverage Status](https://img.shields.io/coveralls/Etherios/python-devicecloud.svg)](https://coveralls.io/r/Etherios/python-devicecloud)
+[![Latest Version](https://pypip.in/version/devicecloud/badge.svg)](https://pypi.python.org/pypi/devicecloud/)
+[![Supported Python versions](https://pypip.in/py_versions/devicecloud/badge.svg)](https://pypi.python.org/pypi/devicecloud/)
+[![License](https://pypip.in/license/devicecloud/badge.svg)](https://pypi.python.org/pypi/devicecloud/)
 
-Be sure to check out the [full API
-documentation](http://etherios.github.io/python-devicecloud) as well.
+Be sure to check out the [full documentation](http://etherios.github.io/python-devicecloud).
 
 Overview
 --------


### PR DESCRIPTION
There are also badges available for things like downloads on pypi
and other items, but these seem the most useful in general.  It's
a nice way to see the currently published version on pypi as
well as calling out the license/supported versions.

You can see other badges based on pypi info at https://pypip.in/.   What do you think @tpmanley and @swstack 
