### PR TITLE
coverage: newer coverage, python-coveralls, and passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27,py32,py33,py34,pypy
 
 [testenv]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps=
   -rtest-requirements.txt
 commands=nosetests -m '^(int|unit)?[Tt]est'
@@ -9,8 +10,8 @@ commands=nosetests -m '^(int|unit)?[Tt]est'
 [testenv:coverage]
 deps=
   {[testenv]deps}
-  coverage>=3.6,<3.999
-  coveralls
+  coverage
+  python-coveralls
 commands =
   coverage run --branch --omit={envdir}/* {envbindir}/nosetests
   coveralls


### PR DESCRIPTION
This change fixes coveralls.io integration by changing a few things:

1. passenv is now required in order for environment variables to
   make it to the coveralls script as described in the readme for
   python-coveralls.  This is how the script knows how to authenticate
   with coveralls.io
2. We moved to using python-coveralls instead of coveralls.
3. Due to #2, we can use a newer coverage