### PR TITLE
quality: add codeclimate badge and exclude tests

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,20 @@
+#
+# ---Choose Your Languages---
+# To disable analysis for a certain language, set the language to `false`.
+# For help setting your languages:
+# http://docs.codeclimate.com/article/169-configuring-analysis-languages
+#
+languages:
+  Ruby: false
+  Javascript: false
+  PHP: false
+  Python: true
+
+#
+# ---Exclude Files or Directories---
+# List the files or directories you would like excluded from analysis.
+# For help setting your exclude paths:
+# http://docs.codeclimate.com/article/166-excluding-files-folders
+#
+exclude_paths:
+  - devicecloud/test/**

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Python Device Cloud Library
 
 [![Build Status](https://img.shields.io/travis/digidotcom/python-devicecloud.svg)](https://travis-ci.org/digidotcom/python-devicecloud)
 [![Coverage Status](https://img.shields.io/coveralls/digidotcom/python-devicecloud.svg)](https://coveralls.io/r/digidotcom/python-devicecloud)
+[![Code Climate](https://img.shields.io/codeclimate/github/digidotcom/python-devicecloud.svg)](https://codeclimate.com/github/digidotcom/python-devicecloud)
 [![Latest Version](https://img.shields.io/pypi/v/devicecloud.svg)](https://pypi.python.org/pypi/devicecloud/)
 [![License](https://img.shields.io/badge/license-MPL%202.0-blue.svg)](https://github.com/digidotcom/python-devicecloud/blob/master/LICENSE)
 


### PR DESCRIPTION
There were a few files in tests that, understandably, contain some
level of code duplication.  According to the codeclimate docs and
common sense, tests should be excluded from the judgement of the
overall health of the codebase.

https://codeclimate.com/github/digidotcom/python-devicecloud