### PR TITLE
travis: explicitly depend on coverage 3.7.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands=nosetests -m '^(int|unit)?[Tt]est'
 [testenv:coverage]
 deps=
   {[testenv]deps}
-  coverage
+  coverage==3.7.1
   python-coveralls
 commands =
   coverage run --branch --omit={envdir}/* {envbindir}/nosetests


### PR DESCRIPTION
This dependency is included in python-coveralls but not installed
for some reason.

Signed-off-by: Paul Osborne <paul.osborne@digi.com>