### PR TITLE
Fix XML request formatting for group targets

### DIFF
--- a/devicecloud/sci.py
+++ b/devicecloud/sci.py
@@ -63,7 +63,7 @@ class GroupTarget(TargetABC):
         self._group = group
 
     def to_xml(self):
-        return '<group path="{}">'.format(self._group)
+        return '<group path="{}"/>'.format(self._group)
 
 
 class AsyncRequestProxy(object):


### PR DESCRIPTION
Without this patch, the following error message was received from the Device
Cloud endpoint because of incorrect XML formatting.

Traceback (most recent call last):

  File "./digicloud.py", line 137, in <module>
    stats(get_targets())
  File "./digicloud.py", line 43, in stats
    req = dc.sci.send_sci(operation='send_message', target=target, payload=STATS_PAYLOAD)
  File "/usr/local/lib/python2.7/dist-packages/devicecloud/sci.py", line 220, in send_sci
    return self._conn.post("/ws/sci", full_request)
  File "/usr/local/lib/python2.7/dist-packages/devicecloud/__init__.py", line 287, in post
    return self._make_request("POST", url, data=data, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/devicecloud/__init__.py", line 178, in _make_request
    raise DeviceCloudHttpException(response, err)
devicecloud.DeviceCloudHttpException: HTTP Status 400: <sci_reply version="1.0"><error>Failure to parse SCI request Error on line 1 of document  : The element type "group" must be terminated by the matching end-tag "&lt;/group&gt;". Nested exception: The element type "group" must be terminated by the matching end-tag "&lt;/group&gt;".</error></sci_reply>