### PR TITLE
Fix XML request formatting for group targets

### DIFF
--- a/devicecloud/sci.py
+++ b/devicecloud/sci.py
@@ -63,7 +63,7 @@ class GroupTarget(TargetABC):
         self._group = group
 
     def to_xml(self):
-        return '<group path="{}">'.format(self._group)
+        return '<group path="{}"/>'.format(self._group)
 
 
 class AsyncRequestProxy(object):

--- a/devicecloud/test/unit/test_sci.py
+++ b/devicecloud/test/unit/test_sci.py
@@ -11,7 +11,7 @@ import mock
 import six
 
 from devicecloud import DeviceCloud
-from devicecloud.sci import DeviceTarget, AsyncRequestProxy, ServerCommandInterfaceAPI
+from devicecloud.sci import DeviceTarget, GroupTarget, AsyncRequestProxy, ServerCommandInterfaceAPI
 from devicecloud.test.unit.test_utilities import HttpTestBase
 
 
@@ -77,6 +77,21 @@ class TestSCI(HttpTestBase):
                                '</send_message>'
                                '</sci_request>'))
 
+    def test_sci_successful_group_target(self):
+        self._prepare_sci_response(EXAMPLE_SCI_DEVICE_NOT_CONNECTED)
+        self.dc.get_sci_api().send_sci(
+            operation="send_message",
+            target=GroupTarget("TestGroup"),
+            payload="<reset/>")
+        self.assertEqual(httpretty.last_request().body,
+                         six.b('<sci_request version="1.0">'
+                               '<send_message>'
+                               '<targets>'
+                               '<group path="TestGroup"/>'
+                               '</targets>'
+                               '<reset/>'
+                               '</send_message>'
+                               '</sci_request>'))
 
 class TestGetAsync(HttpTestBase):
     def test_sci_get_async(self):


### PR DESCRIPTION
Without this patch, the following error message was received from the Device
Cloud endpoint because of incorrect XML formatting.

```
Traceback (most recent call last):

  File "./digicloud.py", line 137, in <module>
    stats(get_targets())
  File "./digicloud.py", line 43, in stats
    req = dc.sci.send_sci(operation='send_message', target=target, payload=STATS_PAYLOAD)
  File "/usr/local/lib/python2.7/dist-packages/devicecloud/sci.py", line 220, in send_sci
    return self._conn.post("/ws/sci", full_request)
  File "/usr/local/lib/python2.7/dist-packages/devicecloud/__init__.py", line 287, in post
    return self._make_request("POST", url, data=data, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/devicecloud/__init__.py", line 178, in _make_request
    raise DeviceCloudHttpException(response, err)
devicecloud.DeviceCloudHttpException: HTTP Status 400: <sci_reply version="1.0"><error>Failure to parse SCI request Error on line 1 of document  : The element type "group" must be terminated by the matching end-tag "&lt;/group&gt;". Nested exception: The element type "group" must be terminated by the matching end-tag "&lt;/group&gt;".</error></sci_reply>
```